### PR TITLE
Update config-database-name with info re watched db limitations

### DIFF
--- a/src/config.md
+++ b/src/config.md
@@ -115,7 +115,7 @@ use an empty string as the namespace value.  For example, `change-stream-namespa
 
 string (default `monstache`) 
 
-The name of the MongoDB database that monstache will store metadata under.  This metadata includes information to support resuming from a specific point in the oplog and managing cluster mode. This database is only written to for some configurations.  Namely, if you specify `cluster-name` or enable `resume`.
+The name of the MongoDB database that monstache will store metadata under.  This metadata includes information to support resuming from a specific point in the oplog and managing cluster mode. This database is only written to for some configurations.  Namely, if you specify `cluster-name`, enable `resume` or set `direct-read-stateful`. WARNING: If you are listening to changes via `change-stream-namespaces`, you cannot set the same database to both listen to changes & store the configs in.
 
 ## cluster-name
 


### PR DESCRIPTION
Add extra info to config-database-name with limitation that has caught me out.

Based on:
https://github.com/rwynn/monstache/issues/474#issuecomment-759119028

P.S.: Is there good reason for this limitation? I never watch the entire db but collections only. Seems like being able to store Monstache configs in same db should be fine. Would be much neater too in deployments with stringent access control, where requirement for provisioned databases suddenly doubles from 1 to 2.